### PR TITLE
Add flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "A flake for the SkiCon Hugo website";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import (builtins.fetchTarball {
+        url = "https://github.com/NixOS/nixpkgs/archive/05bbf675397d5366259409139039af8077d695ce.tar.gz"; # Pin the version of Hugo used in GH Workflows 
+        sha256 = "1r26vjqmzgphfnby5lkfihz6i3y70hq84bpkwd43qjjvgxkcyki0";
+      }) {
+        inherit system;
+      };
+    hugoScript = pkgs.writeShellScriptBin "hugo-server" ''
+        #!/usr/bin/env bash
+        nix develop --command hugo server --watch --bind=0.0.0.0 --baseURL=http://localhost:1313
+      '';
+    in {
+      packages.default = pkgs.hugo;
+
+      devShell = pkgs.mkShell {
+        buildInputs = [
+          pkgs.hugo
+        ];
+      };
+
+      defaultPackage = hugoScript;
+
+      apps.default = {
+        type = "app";
+        program = "${hugoScript}/bin/hugo-server";
+      };
+    });
+}


### PR DESCRIPTION
I want to contribute this Nix Flake as it makes it easy to get up and running for Nix users.  It will run the site locally with all dependencies in place. I am pinning the version of Hugo we're using on GH as the site breaks on the newer version. 